### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PL_microEPD
-version=1.1.02
+version=1.1.2
 author=Robert Poser <paperino.display@gmail.com>
 maintainer=Robert Poser <paperino.display@gmail.com>
 license=BSD-3-Clause


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: 1.1.02
```
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/